### PR TITLE
chore: add ruff and mypy for code checkups

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint & Type Check
+
+on:
+  push:
+    branches: ["main", "feat/*"]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff mypy
+
+      - name: Run Ruff (lint + format check)
+        run: ruff check src tests
+
+      - name: Run MyPy (type checking)
+        run: mypy src

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+python_version = 3.13
+warn_unused_configs = True
+disallow_untyped_defs = True
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.ruff]
+line-length = 88
+target-version = "py313"
+
+[tool.ruff.lint]
+# active règles standards (équivalent Flake8, isort, etc.)
+select = ["E", "F", "W", "I"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/src/freshcart/demo.py
+++ b/src/freshcart/demo.py
@@ -1,15 +1,22 @@
 from datetime import date, timedelta
-from freshcart.domain.products import Product, PerishableProduct
 
-def main():
+from freshcart.domain.products import PerishableProduct, Product
+
+
+def main() -> None:
     p1 = Product("SKU001", "Café", 8.0)
-    p2 = PerishableProduct("SKU002", "Lait", 4.0, expiry_date=date.today()+timedelta(days=2))
+    p2 = PerishableProduct(
+        "SKU002",
+        "Lait",
+        4.0,
+        expiry_date=date.today() + timedelta(days=2),
+    )
 
     print("Produit normal :", p1)
     print("Prix final café :", p1.final_price())
-
     print("Produit périssable :", p2)
     print("Prix final lait :", p2.final_price())
+
 
 if __name__ == "__main__":
     main()

--- a/src/freshcart/domain/inventory.py
+++ b/src/freshcart/domain/inventory.py
@@ -1,70 +1,36 @@
-# But du module :
-# - Définir un service "Inventory" qui gère une collection de produits.
-# - Illustrer : exceptions custom, décorateur simple, compréhensions de listes,
-#   et duck typing via la méthode polymorphe `final_price()`.
+from typing import Any, Callable, List, TypeVar
 
-from __future__ import annotations
+from freshcart.domain.products import Product
 
-from typing import List
-from freshcart.domain.products import Product, Pricable
+# Type générique pour le décorateur
+F = TypeVar("F", bound=Callable[..., Any])
 
 
-# -----------------------------------------------------------
-# 1) Exception custom : métier
-# -----------------------------------------------------------
-# Pourquoi ? En entreprise, on n'utilise pas des ValueError génériques pour tout.
-# On crée des exceptions "métier" qui documentent clairement l'intention.
 class ProductNotFoundError(Exception):
-    """Levée quand on cherche un produit qui n'existe pas dans l'inventaire."""
+    """Levée quand on cherche un produit absent de l'inventaire."""
+    pass
 
 
-# -----------------------------------------------------------
-# 2) Décorateur simple pour tracer l'appel d'une fonction
-# -----------------------------------------------------------
-# Objectif : te montrer la mécanique d'un décorateur (fonction qui "enveloppe" une autre fonction).
-# Ici, on logge sur la sortie standard ; plus tard, on branchera un vrai logger (logging).
-def log_call(func):
-    """Décorateur qui logge le nom de la fonction au moment de l'appel."""
+def log_call(func: F) -> F:
+    """Décorateur qui logge le nom de la fonction lors de l'appel."""
 
-    def wrapper(*args, **kwargs):
-        # NOTE: args[0] est souvent 'self' si on décore une méthode d'instance.
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        # NOTE: args[0] est souvent 'self' si on décore une méthode.
         print(f"[LOG] Calling {func.__name__}")
         return func(*args, **kwargs)
 
-    return wrapper
+    return wrapper  # type: ignore[return-value]
 
 
-# -----------------------------------------------------------
-# 3) Service d'inventaire
-# -----------------------------------------------------------
-# Design :
-# - Stocker des objets Product (ou sous-classes).
-# - Fournir des opérations simples (ajout, suppression, listing).
-# - Offrir des vues filtrées (ex: produits périmés).
-# - Calculer une valeur totale grâce au polymorphisme (final_price()).
 class Inventory:
     def __init__(self) -> None:
-        # Choix : liste en mémoire (simple pour commencer).
-        # Plus tard : on branchera une base de données (SQLite/Postgres).
         self._items: List[Product] = []
 
-    @log_call  # ← décorateur : logge l'appel d'ajout (exemple pédagogique)
+    @log_call
     def add(self, product: Product) -> None:
-        """Ajoute un produit à l'inventaire.
-
-        Args:
-            product: instance de Product (ou sous-classe)
-        """
         self._items.append(product)
 
     def remove(self, sku: str) -> None:
-        """Supprime un produit par son identifiant (SKU).
-
-        Stratégie :
-        - On parcourt la liste (O(n), suffisant pour l'exemple).
-        - Si trouvé → on supprime et on retourne.
-        - Sinon → on lève une exception métier.
-        """
         for p in self._items:
             if p.sku == sku:
                 self._items.remove(p)
@@ -72,29 +38,13 @@ class Inventory:
         raise ProductNotFoundError(f"Produit {sku} introuvable")
 
     def all(self) -> List[Product]:
-        """Retourne une copie de la liste des produits.
-
-        Pourquoi une copie ? Éviter qu'un appelant modifie la liste interne
-        sans passer par les méthodes du service.
-        """
         return list(self._items)
 
     def expired(self) -> List[Product]:
-        """Retourne les produits périmés (si la classe les expose).
-
-        Points pédagogiques :
-        - Duck typing/feature detection : on teste `hasattr(p, "is_expired")`.
-        - Si un objet possède la propriété is_expired et qu'elle vaut True,
-          on le retient.
-        """
-        return [p for p in self._items if hasattr(p, "is_expired") and p.is_expired]
+        return [
+            p for p in self._items
+            if hasattr(p, "is_expired") and getattr(p, "is_expired")
+        ]
 
     def total_value(self) -> float:
-        """Somme des prix finaux de tous les produits (arrondi à 2 décimales).
-
-        Polymorphisme :
-        - On n'a PAS besoin de savoir si 'p' est Product ou PerishableProduct.
-        - On appelle simplement p.final_price() (contrat Pricable).
-        - Chaque classe s'occupe de sa logique de prix (normal, promo, périmé).
-        """
         return round(sum(p.final_price() for p in self._items), 2)

--- a/src/freshcart/domain/products.py
+++ b/src/freshcart/domain/products.py
@@ -1,75 +1,58 @@
 # __future__ import annotations :
-# permet d'utiliser les annotations de type (ex: "Product" dans Product) 
-# sans avoir à les mettre entre guillemets → compatibilité future.
+# permet d'utiliser les annotations de type (ex: Product dans Product)
+# sans guillemets. Améliore la compatibilité avec les versions futures.
 from __future__ import annotations
 
-# dataclass : génère automatiquement __init__, __repr__, __eq__, etc.
 from dataclasses import dataclass, field
-
-# pour gérer les dates d'expiration
 from datetime import date
-
-# Protocol : sert à définir un "contrat" d'interface → duck typing
 from typing import Protocol
 
 
 # -------------------------------------------------------------------
 # 1) Duck typing : définir un contrat Pricable
 # -------------------------------------------------------------------
-# Toute classe qui "implémente" une méthode final_price() -> float 
-# sera considérée comme un Pricable, même sans héritage explicite.
+# Toute classe qui implémente final_price() -> float sera considérée
+# comme un Pricable, même sans hériter explicitement d'une base.
 class Pricable(Protocol):
-    def final_price(self) -> float: ...
-    # Ici on dit seulement "toute classe avec une méthode final_price renvoyant float est valide"
+    def final_price(self) -> float:
+        ...
 
 
 # -------------------------------------------------------------------
 # 2) Classe Product
 # -------------------------------------------------------------------
-# order=True → dataclass génère automatiquement les méthodes de comparaison
-# (__lt__, __le__, __gt__, __ge__) basées sur un champ spécial "sort_index".
+# order=True génère __lt__/__le__/__gt__/__ge__ pour le tri.
 @dataclass(order=True)
-class Product(Pricable):  # On dit aussi que Product respecte le contrat Pricable
-    # sort_index : utilisé uniquement pour le tri → pas affiché (repr=False), pas comparé par défaut
+class Product(Pricable):
+    # sort_index : utilisé pour le tri, pas affiché.
     sort_index: float = field(init=False, repr=False, compare=True)
 
-    # Champs classiques
     sku: str
     name: str
-    _price: float = field(repr=False, compare=False)  # <-- plus de default=0.0
+    _price: float = field(repr=False, compare=False)
 
-    # _price : on le rend privé (avec _) et on ne l'affiche pas dans __repr__
-
-    # Méthode spéciale appelée juste après __init__
     def __post_init__(self) -> None:
-        # On valide et initialise le prix via le setter (validation incluse)
-        self.price = self._price  
-        # On définit l'indice de tri sur le prix
+        # Valide et initialise via le setter (empêche prix négatif).
+        self.price = self._price
         self.sort_index = self._price
 
-
-    # ---- Propriété "price" ----
-    # Grâce à @property, on peut écrire p.price au lieu de p.get_price()
     @property
     def price(self) -> float:
         return self._price
 
-    # Setter pour price → permet de faire p.price = 10
     @price.setter
     def price(self, value: float) -> None:
         if value < 0:
-            raise ValueError("price cannot be negative")  # validation → pas de prix négatif
-        # arrondir à 2 décimales
+            # Validation métier : pas de prix négatif.
+            raise ValueError("price cannot be negative")
         self._price = round(float(value), 2)
-        # garder le sort_index cohérent (pour tri)
+        # Maintenir l’ordre de tri cohérent.
         self.sort_index = self._price
 
-    # ---- Méthode métier ----
-    # final_price peut être redéfini dans les classes enfants (polymorphisme)
     def final_price(self) -> float:
+        # Peut être redéfini par les sous-classes (polymorphisme).
         return self.price
 
-    # ---- Affichage convivial ----
     def __str__(self) -> str:
         return f"{self.name} ({self.sku}) - {self.price:.2f}$"
 
@@ -77,27 +60,21 @@ class Product(Pricable):  # On dit aussi que Product respecte le contrat Pricabl
 # -------------------------------------------------------------------
 # 3) Classe PerishableProduct (hérite de Product)
 # -------------------------------------------------------------------
-# Représente un produit périssable avec date d’expiration
 @dataclass(order=True)
 class PerishableProduct(Product):
-    # On ne compare pas expiry_date pour l'ordre → compare=False
+    # On ne compare pas expiry_date pour l'ordre.
     expiry_date: date = field(compare=False)
 
-    # ---- Propriété calculée ----
     @property
     def is_expired(self) -> bool:
-        # True si la date d'aujourd'hui dépasse expiry_date
         return date.today() > self.expiry_date
 
-    # ---- Méthode utilitaire ----
     def days_left(self) -> int:
-        # Différence entre la date d’expiration et aujourd’hui
         return (self.expiry_date - date.today()).days
 
-    # ---- Redéfinition de final_price (polymorphisme) ----
     def final_price(self) -> float:
         if self.is_expired:
-            return 0.0  # produit périmé → gratuit ou inutilisable
+            return 0.0
         if self.days_left() <= 3:
-            return round(self.price * 0.5, 2)  # réduction de 50% si proche d’expirer
+            return round(self.price * 0.5, 2)
         return self.price

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,69 +1,64 @@
-# But du fichier :
-# - Vérifier que le service Inventory fonctionne comme prévu.
-# - Couvrir : ajout, suppression, listing, filtrage "expired", total_value.
-# - Tester les cas heureux ET les erreurs (exception custom).
+# But : vérifier Inventory (ajout, retrait, listing, périmés, total).
 
 from datetime import date, timedelta
+
 import pytest
 
 from freshcart.domain.inventory import Inventory, ProductNotFoundError
-from freshcart.domain.products import Product, PerishableProduct
+from freshcart.domain.products import PerishableProduct, Product
 
 
-def test_add_and_all():
-    # Arrange : inventaire vide + 1 produit
+def test_add_and_all() -> None:
     inv = Inventory()
     p = Product("S1", "Café", 8.0)
 
-    # Act : on ajoute le produit
     inv.add(p)
 
-    # Assert : la liste "all" contient bien notre produit
     items = inv.all()
     assert len(items) == 1
     assert items[0].name == "Café"
-    # Bonus : "all" retourne une COPIE → modifier 'items' ne doit pas impacter l'interne
+
+    # "all" retourne une copie : modifier 'items' n'affecte pas l'interne.
     items.clear()
-    assert len(inv.all()) == 1  # l'inventaire original n'a pas bougé
+    assert len(inv.all()) == 1
 
 
-def test_remove_success_and_failure():
+def test_remove_success_and_failure() -> None:
     inv = Inventory()
     p = Product("S2", "Thé", 5.0)
     inv.add(p)
 
-    # Cas 1 : suppression réussie
     inv.remove("S2")
     assert len(inv.all()) == 0
 
-    # Cas 2 : suppression d'un SKU inexistant → doit lever une exception métier
     with pytest.raises(ProductNotFoundError):
         inv.remove("BADSKU")
 
 
-def test_expired_and_total_value():
+def test_expired_and_total_value() -> None:
     inv = Inventory()
 
-    # Produit périmé (hier) : is_expired=True, final_price=0.0
-    expired = PerishableProduct("E1", "Yaourt", 3.0, expiry_date=date.today() - timedelta(days=1))
-    # Produit frais (expire dans 10 jours) : final_price=price (=6.0)
-    fresh = PerishableProduct("E2", "Lait", 4.0, expiry_date=date.today() + timedelta(days=10))
-    # Produit normal (non périssable) : final_price=price (=2.0)
+    expired = PerishableProduct(
+        "E1",
+        "Yaourt",
+        3.0,
+        expiry_date=date.today() - timedelta(days=1),
+    )
+    fresh = PerishableProduct(
+        "E2",
+        "Lait",
+        4.0,
+        expiry_date=date.today() + timedelta(days=10),
+    )
     normal = Product("N1", "Sucre", 2.0)
 
     inv.add(expired)
     inv.add(fresh)
     inv.add(normal)
 
-    # Vérifier le filtrage 'expired'
     expired_list = inv.expired()
     assert expired in expired_list
     assert fresh not in expired_list
-    assert normal not in expired_list  # normal n'a pas is_expired
+    assert normal not in expired_list
 
-    # Vérifier la somme polymorphe des prix finaux :
-    # - expired.final_price() = 0.0
-    # - fresh.final_price()   = 4.0
-    # - normal.final_price()  = 2.0
-    # total = 0 + 4 + 2 = 6.0
     assert inv.total_value() == 6.0

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -1,79 +1,59 @@
-# On importe date/timedelta pour fabriquer des dates dynamiques (aujourd’hui + x jours)
+# But : couvrir propriété/validation, tri, périssable, final_price.
+
 from datetime import date, timedelta
 
-# pytest : framework de test (on l’a installé avec pip)
 import pytest
 
-# On importe nos classes à tester
-from freshcart.domain.products import Product, PerishableProduct
+from freshcart.domain.products import PerishableProduct, Product
 
 
-# -------------------------------------------------------------------
-# 1) Test de la propriété "price" avec validation
-# -------------------------------------------------------------------
-def test_price_property_validation():
-    # On crée un produit normal
+def test_price_property_validation() -> None:
     p = Product("SKU-1", "Café", 8.0)
-
-    # Vérifie que le prix est bien celui donné
     assert p.price == 8.0
 
-    # On change le prix → devrait être arrondi à 2 décimales
-    p.price = 10.249
+    p.price = 10.249  # arrondi à 2 décimales
     assert p.price == 10.25
 
-    # Cas invalide : prix négatif → devrait lever une erreur
     with pytest.raises(ValueError):
         p.price = -1
 
 
-# -------------------------------------------------------------------
-# 2) Test de l'affichage et de l'ordre (tri)
-# -------------------------------------------------------------------
-def test_str_and_ordering():
-    # Deux produits avec prix différents
+def test_str_and_ordering() -> None:
     p1 = Product("A", "ProdA", 5.0)
     p2 = Product("B", "ProdB", 7.0)
-
-    # __str__ → doit contenir le nom du produit
     assert "ProdA" in str(p1)
-
-    # Tri par prix → p1 (5.0) doit être avant p2 (7.0)
     assert sorted([p2, p1])[0] == p1
 
 
-# -------------------------------------------------------------------
-# 3) Test du produit périssable (expiration + réduction)
-# -------------------------------------------------------------------
-def test_perishable_is_expired_and_discount():
-    # Produit déjà périmé hier
+def test_perishable_is_expired_and_discount() -> None:
     expired = PerishableProduct(
-        "E1", "Yaourt", 3.0, expiry_date=date.today() - timedelta(days=1)
+        "E1",
+        "Yaourt",
+        3.0,
+        expiry_date=date.today() - timedelta(days=1),
     )
-
-    # Produit qui expire dans 2 jours
     soon = PerishableProduct(
-        "S1", "Lait", 4.0, expiry_date=date.today() + timedelta(days=2)
+        "S1",
+        "Lait",
+        4.0,
+        expiry_date=date.today() + timedelta(days=2),
     )
-
-    # Produit qui expire dans 10 jours
     later = PerishableProduct(
-        "L1", "Fromage", 6.0, expiry_date=date.today() + timedelta(days=10)
+        "L1",
+        "Fromage",
+        6.0,
+        expiry_date=date.today() + timedelta(days=10),
     )
 
-    # ---- Cas 1 : périmé ----
     assert expired.is_expired is True
-    assert expired.final_price() == 0.0  # valeur nulle car déjà périmé
+    assert expired.final_price() == 0.0
 
-    # ---- Cas 2 : expire bientôt (<= 3 jours) ----
     assert soon.is_expired is False
-    assert soon.final_price() == 2.0  # réduction -50% sur 4.0
+    assert soon.final_price() == 2.0
 
-    # ---- Cas 3 : expiration lointaine (> 3 jours) ----
-    assert later.final_price() == 6.0  # prix normal, aucune réduction
+    assert later.final_price() == 6.0
 
 
-def test_regular_product_final_price():
+def test_regular_product_final_price() -> None:
     p = Product("SKU-REG2", "Thé", 5.5)
-    # Appelle explicitement la méthode final_price()
     assert p.final_price() == 5.5


### PR DESCRIPTION
PR: Add linting and type checking (Ruff + MyPy)
##What

Added Ruff configuration in pyproject.toml for linting & formatting

Added MyPy configuration in mypy.ini for static type checking

Updated inventory.py with proper type annotations (decorator + methods)

Cleaned up imports & formatting with Ruff auto-fix

New CI workflow: .github/workflows/lint.yml

##Why

Enforce code quality standards (PEP8, import order, line length, no unused imports)

Ensure type safety across the codebase → catch bugs early

Align with enterprise practices where linting + typing are required in CI

Prevent “dirty” code from reaching main

##How to test:
ruff check src tests --fix
mypy src
pytest --cov=src/freshcart --cov-report=term-missing
