### PR TITLE
docs: add README and runnable examples; add dev requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,160 @@
-# FreshCart
+# 🛒 FreshCart
 
-Projet d’entraînement Python + DevOps
+Projet d’entraînement **Python + DevOps**
 
-## Objectifs
-- Python “propre” (OOP, tests, packaging, async, API).
-- Outils DevOps : Git/GitHub, CI/CD (GitHub Actions), Docker, Terraform + AWS Free Tier, qualité (SonarQube), sécurité (Snyk), Ansible, etc.
+## 🎯 Objectifs
 
-## Lancement rapide (sanity check)
-```bash
+- Python “propre” : OOP, tests, packaging, async, API.
+- Outils DevOps :
+  - Git/GitHub
+  - CI/CD (GitHub Actions)
+  - Docker
+  - Terraform + AWS Free Tier
+  - Qualité (SonarQube)
+  - Sécurité (Snyk)
+  - Ansible, etc.
+
+## ⚡ Lancement rapide (sanity check)
+
+Après avoir cloné le dépôt et activé votre venv (voir plus bas) :
+
 python hello.py
+
+## 🗂️ Sommaire
+
+- Pré-requis
+- Installation rapide
+- Commandes utiles
+- API Utilisateur
+- Product
+- PerishableProduct
+- Inventory
+- Qualité & CI
+- Structure
+- Dépannage
+
+## 🔧 Pré-requis
+
+- Python 3.11+ (idéal : 3.13)
+- Git
+- Windows (PowerShell/CMD) ou macOS/Linux (Terminal)
+
+## 🚀 Installation rapide
+
+### 1) Cloner le dépôt
+
+git clone <URL_DU_REPO> && cd freshcart
+
+### 2) Créer/activer l’environnement virtuel
+
+# Windows PowerShell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+
+# Windows CMD
+python -m venv .venv
+.\.venv\Scripts\activate.bat
+
+# macOS/Linux
+python3 -m venv .venv
+source .venv/bin/activate
+
+### 3) Installer le package en mode développement (editable)
+
+pip install -e .
+
+# Pour quitter le venv :
+deactivate
+
+## 🛠️ Commandes utiles
+
+# ✅ Tests unitaires avec couverture
+pytest --cov=src/freshcart --cov-report=term-missing
+
+# 🎨 Lint & format (Ruff)
+ruff check src tests --fix
+
+# 🔍 Typage statique (MyPy)
+mypy src
+
+## 📦 API Utilisateur
+
+Le package s’importe sous le nom `freshcart`.
+Les classes principales sont exposées à la racine pour des imports courts.
+
+# --- Product ---
+from freshcart import Product
+
+# 3e argument positionnel = prix initial
+p = Product("SKU001", "Café", 8.0)
+
+# ou en nommé (InitVar "initial_price")
+p = Product(sku="SKU001", name="Café", initial_price=8.0)
+
+p.price            # -> 8.0 (propriété avec validation + arrondi)
+p.final_price()    # -> 8.0 (polymorphisme, peut être surchargé)
+print(p)           # "Café (SKU001) - 8.00$"
+
+# --- PerishableProduct ---
+from freshcart import PerishableProduct
+from datetime import date, timedelta
+
+lait = PerishableProduct(
+    "SKU002", "Lait", 4.0,
+    expiry_date=date.today() + timedelta(days=2)  # paramètre keyword-only
+)
+
+lait.is_expired      # -> False (aujourd'hui < date d'expiration)
+lait.final_price()   # -> 2.0 (remise -50% si <= 3 jours avant expiration)
+
+# --- Inventory ---
+from freshcart import Inventory, Product
+
+inv = Inventory()
+inv.add(Product("SKU001", "Café", 8.0))
+inv.add(Product("SKU003", "Sucre", 2.0))
+
+inv.all()           # -> liste des produits
+inv.expired()       # -> liste des périmés (si périssables)
+inv.total_value()   # -> somme des final_price() (polymorphisme)
+
+## ✅ Qualité & CI
+
+- Tests : Pytest + couverture.
+- Lint : Ruff (PEP 8, ordre d’imports, lignes longues, etc.).
+- Types : MyPy (Protocol/Duck typing, InitVar, annotations).
+
+# ⚙️ CI GitHub Actions
+- .github/workflows/tests.yml → exécute Pytest
+- .github/workflows/lint.yml → exécute Ruff + MyPy
+
+> La CI échoue si le linting, le typing ou les tests échouent → protège la branche `main`.
+
+## 📁 Structure
+
+freshcart/
+  src/freshcart/
+    __init__.py               # expose Product, PerishableProduct, Inventory
+    domain/
+      products.py             # Product, PerishableProduct (+ Pricable/Protocol)
+      inventory.py            # Inventory, exception métier, décorateur log_call
+  tests/                      # tests unitaires (couverture élevée)
+  hello.py                    # sanity check simple (installation Python)
+
+## 🧯 Dépannage
+
+# ❌ ModuleNotFoundError: freshcart
+# Assurez-vous d’avoir bien activé l’environnement et installé le package :
+
+pip install -e .
+
+# ❌ NameError: name 'date' is not defined
+# Pensez à importer :
+
+from datetime import date, timedelta
+
+# ⚠️ Ruff signale I001 (imports non triés) ou E501 (lignes > 88 cols)
+ruff check src tests --fix
+
+# ⚠️ Vérification de type
+mypy src

--- a/examples/demo_discounts.py
+++ b/examples/demo_discounts.py
@@ -1,0 +1,22 @@
+from datetime import date, timedelta
+
+from freshcart import PerishableProduct
+
+
+def main() -> None:
+    bientot = PerishableProduct(
+        "SKU100", "Yaourt", 3.0, expiry_date=date.today() + timedelta(days=2)
+    )
+    plus_tard = PerishableProduct(
+        "SKU101", "Fromage", 6.0, expiry_date=date.today() + timedelta(days=10)
+    )
+    perime = PerishableProduct(
+        "SKU102", "Crème", 5.0, expiry_date=date.today() - timedelta(days=1)
+    )
+
+    for p in (bientot, plus_tard, perime):
+        print(f"{p} | expired={getattr(p,'is_expired')} | final={p.final_price()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/demo_inventory.py
+++ b/examples/demo_inventory.py
@@ -1,0 +1,28 @@
+from datetime import date, timedelta
+
+from freshcart import Inventory, PerishableProduct, Product
+
+
+def main() -> None:
+    inv = Inventory()
+
+    cafe = Product("SKU001", "Café", 8.0)
+    lait = PerishableProduct(
+        "SKU002",
+        "Lait",
+        4.0,
+        expiry_date=date.today() + timedelta(days=2),  # kw-only
+    )
+    sucre = Product("SKU003", "Sucre", 2.0)
+
+    inv.add(cafe)
+    inv.add(lait)
+    inv.add(sucre)
+
+    print("Tous les produits :", inv.all())
+    print("Périmés :", inv.expired())
+    print("Valeur totale (final_price) :", inv.total_value())
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-cov
+ruff
+mypy


### PR DESCRIPTION
## What
- Add complete `README.md` with:
  - Objectifs du projet (Python + DevOps)
  - Installation rapide et sanity check
  - Commandes utiles (tests, lint, mypy)
  - Documentation de l’API (Product, PerishableProduct, Inventory)
  - Structure du projet
  - Section Dépannage
- Add `examples/` folder with:
  - `demo_inventory.py` (inventaire avec produits)
  - `demo_discounts.py` (remises pour produits périssables)
- Add `requirements-dev.txt` regroupant les dépendances de développement (pytest, ruff, mypy, …)

## Why
- Fournir une documentation claire et immédiate pour tout nouvel arrivant
- Donner des scripts d’exemples prêts à l’emploi pour comprendre l’API rapidement
- Centraliser les dépendances dev pour un setup standardisé

## How to test
```bash
# Lire le README.md
cat README.md

# Exécuter les exemples
python examples/demo_inventory.py
python examples/demo_discounts.py

# Installer les dépendances de dev
pip install -r requirements-dev.txt
