### PR TITLE
ci(docker): build image and run tests (pytest, ruff, mypy) in container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.pytest_cache/
+.coverage
+htmlcov/

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -1,0 +1,43 @@
+name: Docker - Build & Test
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-and-test:
+    name: Build image and run tests in container
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1) Récupère le code de la PR / du push
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # 2) (Optionnel) Activer Buildx (moteur moderne de build Docker)
+      #    Utile si tu ajoutes du caching plus tard ou des builds multi-plateformes.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # 3) Construire l'image Docker de ce repo
+      #    Le tag local "freshcart-ci" évite les collisions avec d'autres jobs.
+      - name: Build image
+        run: |
+          docker build -t freshcart-ci .
+
+      # 4) Lancer les tests (le CMD du Dockerfile lance pytest avec couverture)
+      - name: Run unit tests in container (pytest)
+        run: |
+          docker run --rm freshcart-ci
+
+      # 5) (Optionnel) Overrider le CMD pour lancer Ruff
+      - name: Lint (Ruff) in container
+        run: |
+          docker run --rm freshcart-ci ruff check src tests
+
+      # 6) (Optionnel) Overrider le CMD pour lancer MyPy
+      - name: Type-check (MyPy) in container
+        run: |
+          docker run --rm freshcart-ci mypy src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# 1) On part d'une image officielle Python (ici version 3.13 allégée "slim")
+# 👉 Cela évite d’installer Python à la main : tout est déjà fourni par l’image.
+FROM python:3.13-slim
+
+# 2) Définir le dossier de travail à l'intérieur du container
+# 👉 Tous les prochains RUN, COPY, CMD s’exécuteront dans ce dossier.
+WORKDIR /app
+
+# 3) Copier tout le projet dans l’image (dossier actuel -> /app)
+# 👉 Le code, tests, requirements seront donc présents dans le container.
+COPY . .
+
+# 4) Mettre à jour pip + installer le package et les dépendances de dev
+# - pip install -e . → installe ton projet en "mode editable"
+# - pip install -r requirements-dev.txt → installe pytest, ruff, mypy
+RUN pip install --upgrade pip && \
+    pip install -e . && \
+    pip install -r requirements-dev.txt
+
+# 5) Définir la commande par défaut du container
+# 👉 Ici, on lance pytest avec couverture, donc à chaque "docker run freshcart"
+#    les tests s’exécutent automatiquement.
+CMD ["pytest", "--cov=src/freshcart", "--cov-report=term-missing"]


### PR DESCRIPTION
What

Add GitHub Actions workflow docker-tests.yml

Build Docker image and run pytest inside container

Run Ruff & MyPy in the same container (override CMD)

Why

Ensure reproducible tests/lint/types in a standardized Docker env

Catch “works on my machine” issues early

How to test

Open the PR → CI should:

docker build -t freshcart-ci .

docker run --rm freshcart-ci (pytest)

docker run --rm freshcart-ci ruff check src tests

docker run --rm freshcart-ci mypy src

Notes

No app logic changes

Future step: push image to a registry (GHCR/ECR) on tags