### PR TITLE
FC-3: chore(api): scaffold FastAPI package structure

### DIFF
--- a/src/freshcart/api/__init__.py
+++ b/src/freshcart/api/__init__.py
@@ -1,0 +1,8 @@
+"""
+FreshCart API package.
+
+⚠️ FC-3 (scaffolding) :
+- On crée l’ossature du package API.
+- L’app FastAPI et les routes seront ajoutées aux étapes FC-4/FC-5.
+"""
+__all__: list[str] = []

--- a/src/freshcart/api/main.py
+++ b/src/freshcart/api/main.py
@@ -1,0 +1,20 @@
+"""
+Point d’entrée de l’API.
+
+FC-3 (placeholder) :
+- On ne dépend PAS encore de FastAPI ici (pour que le projet reste installable
+  même si tu n’as pas encore ajouté les dépendances).
+- En FC-4, on ajoutera `from fastapi import FastAPI` + une factory `create_app()`.
+- En FC-5, on branchera les routes (health, products, inventory...).
+"""
+
+def create_app_placeholder() -> None:
+    """Petite fonction temporaire pour valider l’import du module en FC-3.
+    Remplacée par `create_app()` (FastAPI) en FC-4.
+    """
+    return None
+
+
+if __name__ == "__main__":
+    # Note dev : en FC-6 on lancera uvicorn ici.
+    print("FreshCart API skeleton ready.")

--- a/src/freshcart/api/routers/__init__.py
+++ b/src/freshcart/api/routers/__init__.py
@@ -1,0 +1,5 @@
+"""
+Sous-paquet pour regrouper les routers FastAPI.
+
+FC-5 : on y créera `health.py`, `products.py`, etc.
+"""

--- a/src/freshcart/api/schemas.py
+++ b/src/freshcart/api/schemas.py
@@ -1,0 +1,6 @@
+"""
+Schémas (Pydantic) pour l’API.
+
+FC-3 : fichier vide avec docstring pour préparer le terrain.
+FC-4 : on y mettra les modèles de requête/réponse (ex: ProductIn, ProductOut).
+"""


### PR DESCRIPTION
## What
- Create API skeleton:
  - src/freshcart/api/{__init__.py, main.py, schemas.py}
  - src/freshcart/api/routers/__init__.py
- No FastAPI imports yet (keeps step FC-3 dependency-free)

## Why
- Prepare clean package layout before adding dependencies/routes (FC-4/FC-5)
- Makes future diffs + reviews smaller and clearer

## How to test
- `ruff check src tests` → should pass
- `mypy src` → should pass
- `pytest` → unchanged tests still pass

## Notes
- Next steps:
  - **FC-4**: add `fastapi`, `uvicorn`, `httpx` and implement `create_app()`
  - **FC-5**: add `/health` and first routers
