### PR TITLE
FC-9: feat(api): add Pydantic schemas, /products endpoints, and integ…

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ pytest-cov
 # Qualité
 ruff
 mypy
+black
 
 # API
 fastapi

--- a/src/freshcart/__init__.py
+++ b/src/freshcart/__init__.py
@@ -3,11 +3,9 @@ Freshcart - package principal
 Expose les objets importants pour éviter les imports trop longs.
 """
 
-
-#from freshcart.domain.products import Product
-#on pourra faire :
-#from freshcart import Product
-
+# from freshcart.domain.products import Product
+# on pourra faire :
+# from freshcart import Product
 
 
 from .domain.inventory import Inventory, ProductNotFoundError

--- a/src/freshcart/api/__init__.py
+++ b/src/freshcart/api/__init__.py
@@ -5,4 +5,5 @@ FreshCart API package.
 - On crée l’ossature du package API.
 - L’app FastAPI et les routes seront ajoutées aux étapes FC-4/FC-5.
 """
+
 __all__: list[str] = []

--- a/src/freshcart/api/main.py
+++ b/src/freshcart/api/main.py
@@ -1,69 +1,48 @@
-"""
-Point d’entrée de l’API FreshCart.
-
-FC-4 : on introduit une *app factory* FastAPI : `create_app()`.
-- Une "factory" renvoie une instance d'application configurée.
-- Avantages :
-  - Tests faciles (tu crées une app isolée par test).
-  - Config différente selon l'environnement (dev/test/prod).
-  - Évite le code global exécuté au moment de l'import.
-
-⚠️ Pas de routes ici : elles arrivent en FC-5 (health, products, inventory...).
-"""
-
 from __future__ import annotations
 
 from typing import Any, Dict
 
 from fastapi import FastAPI
 
+from freshcart.domain.inventory import Inventory  # NEW
+
 
 def create_app(settings: Dict[str, Any] | None = None) -> FastAPI:
     """
-    Crée et configure l'application FastAPI.
-
-    Args:
-        settings: dictionnaire optionnel de configuration (FC-7/8 : on
-        pourra y passer des choses comme DATABASE_URL, LOG_LEVEL, etc.)
-
-    Returns:
-        Instance FastAPI prête à l'emploi (sans routes pour l’instant).
+    Factory d'application (recommandée):
+    - facilite les tests
+    - permet d'injecter des settings plus tard
     """
-    # 1) Créer l'instance
     app = FastAPI(
         title="FreshCart API",
         version="0.1.0",
         description="API d'entraînement pour gérer des produits/inventaires.",
-        docs_url="/docs",         # Swagger UI
-        redoc_url="/redoc",       # Redoc (autre UI)
+        docs_url="/docs",
+        redoc_url="/redoc",
         openapi_url="/openapi.json",
     )
 
-    # 2) Appliquer une config basique si fournie
     settings = settings or {}
-    # Exemple (plus tard) : app.state.db = make_db(settings["DATABASE_URL"])
 
-    # 3) Brancher les routers (FC-5)
-    # from .routers import health, products
-    # app.include_router(health.router)
-    # app.include_router(products.router, prefix="/products", tags=["products"])
-    from .routers import health
+    # --- état applicatif en mémoire (pour le sprint actuel) ---
+    app.state.inventory = Inventory()  # NEW
+
+    # --- routers ---
+    from .routers import health, products  # NEW
+
     app.include_router(health.router)
-
-    # 4) Middlewares (CORS, sécurité) viendront plus tard
+    app.include_router(products.router)  # NEW
 
     return app
 
 
-# Exécution locale (dev) avec `python -m freshcart.api.main`
-# → C'est pratique quand tu ne veux pas mémoriser la commande uvicorn.
 if __name__ == "__main__":
     import uvicorn
 
     uvicorn.run(
-        "freshcart.api.main:create_app",  # module:callable (factory)
-        factory=True,                     # indique à uvicorn que c'est une factory
+        "freshcart.api.main:create_app",
+        factory=True,
         host="127.0.0.1",
         port=8000,
-        reload=True,                      # auto-reload en dev
+        reload=True,
     )

--- a/src/freshcart/api/routers/products.py
+++ b/src/freshcart/api/routers/products.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+# SUPPRIMER: from datetime import date
+from typing import List, Literal  # <-- on réintroduit List pour mypy compat
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from freshcart.api.schemas import ProductCreate, ProductOut
+from freshcart.domain.inventory import Inventory
+from freshcart.domain.products import PerishableProduct, Product
+
+router = APIRouter(prefix="/products", tags=["products"])
+
+
+def get_inventory(request: Request) -> Inventory:
+    inv = getattr(request.app.state, "inventory", None)
+    if inv is None:
+        raise RuntimeError("Inventory is not initialized on app.state")
+    return inv
+
+
+def to_product_out(p: Product) -> ProductOut:
+    type_value: Literal["regular", "perishable"]
+    if hasattr(p, "expiry_date"):
+        type_value = "perishable"
+        expiry = getattr(p, "expiry_date")
+    else:
+        type_value = "regular"
+        expiry = None
+
+    return ProductOut(
+        sku=p.sku,
+        name=p.name,
+        type=type_value,
+        price=p.price,
+        final_price=p.final_price(),
+        expiry_date=expiry,
+    )
+
+
+@router.post("", response_model=ProductOut, status_code=status.HTTP_201_CREATED)
+def create_product(
+    payload: ProductCreate, inv: Inventory = Depends(get_inventory)
+) -> ProductOut:
+    if any(it.sku == payload.sku for it in inv.all()):
+        raise HTTPException(status_code=400, detail="SKU already exists")
+
+    if payload.type == "regular":
+        p = Product(payload.sku, payload.name, payload.initial_price)
+    else:
+        assert payload.expiry_date is not None, "expiry_date validated by Pydantic"
+        p = PerishableProduct(
+            payload.sku,
+            payload.name,
+            payload.initial_price,
+            expiry_date=payload.expiry_date,
+        )
+
+    inv.add(p)
+    return to_product_out(p)
+
+
+@router.get("", response_model=List[ProductOut])  # <-- List[...] au lieu de list[...]
+def list_products(inv: Inventory = Depends(get_inventory)) -> List[ProductOut]:
+    items = sorted(inv.all())
+    return [to_product_out(p) for p in items]

--- a/src/freshcart/api/schemas.py
+++ b/src/freshcart/api/schemas.py
@@ -1,6 +1,65 @@
 """
-Schémas (Pydantic) pour l’API.
+Schemas Pydantic pour l'API FreshCart.
 
-FC-3 : fichier vide avec docstring pour préparer le terrain.
-FC-4 : on y mettra les modèles de requête/réponse (ex: ProductIn, ProductOut).
+Rôle:
+- Définir les contrats d'ENTRÉE (payloads) et de SORTIE (réponses).
+- Pydantic valide automatiquement les données et alimente la doc Swagger.
 """
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+# ---------- Entrées ----------
+
+
+class ProductCreate(BaseModel):
+    """
+    Requête de création de produit.
+
+    - initial_price >= 0 (validation)
+    - type = "regular" | "perishable"
+    - si "perishable" -> expiry_date est requis (validation "after")
+    """
+
+    sku: str = Field(..., min_length=1, max_length=50)
+    name: str = Field(..., min_length=1, max_length=200)
+    initial_price: float = Field(..., ge=0.0)
+    type: Literal["regular", "perishable"] = "regular"
+    expiry_date: Optional[date] = None
+
+    # Exemple de validation champ par champ (v2)
+    @field_validator("initial_price")
+    @classmethod
+    def _non_negative(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError("initial_price must be >= 0")
+        # On peut arrondir au passage, pour rester aligné avec le domaine
+        return round(float(v), 2)
+
+    # Validation dépendant de plusieurs champs (v2)
+    @model_validator(mode="after")
+    def _perishable_needs_expiry(self) -> "ProductCreate":
+        if self.type == "perishable" and self.expiry_date is None:
+            raise ValueError("expiry_date is required for perishable products")
+        return self
+
+
+# ---------- Sorties ----------
+
+
+class ProductOut(BaseModel):
+    """
+    Réponse standardisée d'un produit renvoyé par l'API.
+    On expose le prix courant ET le prix calculé `final_price`.
+    """
+
+    sku: str
+    name: str
+    type: Literal["regular", "perishable"]
+    price: float
+    final_price: float
+    expiry_date: Optional[date] = None

--- a/src/freshcart/domain/inventory.py
+++ b/src/freshcart/domain/inventory.py
@@ -8,6 +8,7 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 class ProductNotFoundError(Exception):
     """Levée quand on cherche un produit absent de l'inventaire."""
+
     pass
 
 
@@ -42,7 +43,8 @@ class Inventory:
 
     def expired(self) -> List[Product]:
         return [
-            p for p in self._items
+            p
+            for p in self._items
             if hasattr(p, "is_expired") and getattr(p, "is_expired")
         ]
 

--- a/src/freshcart/domain/products.py
+++ b/src/freshcart/domain/products.py
@@ -28,7 +28,7 @@ class Product(Pricable):
     sort_index: float = field(init=False, repr=False, compare=True)
 
     # champs "publics" obligatoires
-    sku: str   # identifiant unique
+    sku: str  # identifiant unique
     name: str  # nom du produit
 
     # >>> "initial_price" est seulement un paramètre d'init (InitVar),
@@ -44,9 +44,9 @@ class Product(Pricable):
         Méthode appelée automatiquement après __init__.
         On utilise le setter 'price' pour appliquer la validation.
         """
-        self._price = 0.0                 # valeur temporaire
-        self.price = initial_price        # passe par le setter (validation, arrondi)
-        self.sort_index = self._price     # synchroniser l'ordre de tri
+        self._price = 0.0  # valeur temporaire
+        self.price = initial_price  # passe par le setter (validation, arrondi)
+        self.sort_index = self._price  # synchroniser l'ordre de tri
 
     # --- propriété "price" exposée proprement ---
     @property
@@ -76,6 +76,7 @@ class Product(Pricable):
     def __str__(self) -> str:
         """Représentation lisible du produit."""
         return f"{self.name} ({self.sku}) - {self.price:.2f}$"
+
 
 # -------------------------------------------------------------------
 # 3) Classe PerishableProduct (hérite de Product)

--- a/tests/test_ai_products.py
+++ b/tests/test_ai_products.py
@@ -1,0 +1,66 @@
+"""
+Tests d’intégration pour /products.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from fastapi.testclient import TestClient
+
+from freshcart.api.main import create_app
+
+
+def test_create_and_list_regular_product() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    payload = {"sku": "P1", "name": "Café", "initial_price": 8.0, "type": "regular"}
+    r = client.post("/products", json=payload)
+    assert r.status_code == 201
+    data = r.json()
+    assert data["sku"] == "P1"
+    assert data["type"] == "regular"
+    assert data["final_price"] == 8.0
+
+    r2 = client.get("/products")
+    assert r2.status_code == 200
+    items = r2.json()
+    assert any(it["sku"] == "P1" for it in items)
+
+
+def test_perishable_requires_expiry_date() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    bad = {"sku": "X1", "name": "Lait", "initial_price": 4.0, "type": "perishable"}
+    r = client.post("/products", json=bad)
+    assert r.status_code == 422  # pydantic valide: expiry_date requis
+
+
+def test_perishable_discount_rule() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    soon = date.today() + timedelta(days=2)  # <= 3 jours -> -50%
+    payload = {
+        "sku": "X2",
+        "name": "Yaourt",
+        "initial_price": 3.0,
+        "type": "perishable",
+        "expiry_date": soon.isoformat(),
+    }
+    r = client.post("/products", json=payload)
+    assert r.status_code == 201
+    assert r.json()["final_price"] == 1.5
+
+
+def test_duplicate_sku_rejected() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    p = {"sku": "DUP", "name": "Sucre", "initial_price": 2.0}
+    assert client.post("/products", json=p).status_code == 201
+    r = client.post("/products", json=p)
+    assert r.status_code == 400
+    assert r.json()["detail"] == "SKU already exists"


### PR DESCRIPTION
What

Ajout des schemas Pydantic (ProductCreate, ProductOut) pour gérer les entrées/sorties API.

Création des endpoints /products :

POST /products → créer un produit ou produit périssable.

GET /products → lister tous les produits triés, avec leur final_price.

Intégration de Black comme auto-formatter de code.

Tous les tests (pytest) mis à jour et passent ✅.

Vérification statique (mypy) et linting (ruff) validés.

🤔 Why

Les schemas Pydantic garantissent une validation stricte des données reçues par l’API (ex: expiry_date obligatoire pour un périssable).

Les endpoints produits constituent la première vraie feature métier exposée de l’API FastAPI.

Black permet de garder un style de code uniforme (collaboration + CI/CD).

Cette étape concrétise le lien entre domaine métier (Product, PerishableProduct, Inventory) et l’API exposée aux utilisateurs.

🛠️ How

Ajout d’un module api/schemas.py pour centraliser les modèles Pydantic.

Création d’un router api/routers/products.py avec les endpoints.

Connexion dans api/main.py via app.include_router(products.router, prefix="/products").

Ajout de Black dans requirements-dev.txt et exécution locale (black src tests).

Adaptation des tests d’intégration (tests/test_ai_products.py).

📌 Notes

Les imports ont été auto-formatés (ruff --fix + black).

CI validée localement (pytest, ruff, mypy, black).

Prochaine étape → FC-10 : gérer les erreurs métier avancées + tests supplémentaires.