### PR TITLE
FC-10: style(api): fix long line and organize imports for Ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,27 +2,49 @@ name: Lint & Type Check
 
 on:
   push:
-    branches: ["main", "feat/*"]
+    branches: ["**"]           # toutes les branches (ex: FC-9-..., fix/..., etc.)
   pull_request:
+    branches: ["**"]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ruff mypy
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
 
-      - name: Run Ruff (lint + format check)
+      # (Optionnel mais conseillé) cache pip pour accélérer
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dev tools from requirements-dev.txt
+        run: |
+          pip install -r requirements-dev.txt
+          # (facultatif si mypy/ruff parcourent src/ sans importer)
+          # pip install -e .
+
+      - name: Ruff (lint only)
         run: ruff check src tests
 
-      - name: Run MyPy (type checking)
+      - name: MyPy (type checking)
         run: mypy src
+
+      # 🔴 IMPORTANT : Black en mode "check"
+      # --check  : n'écrit rien, échoue s'il y a des diff
+      # --diff   : montre le diff dans les logs (utile pour corriger)
+      - name: Black (format check)
+        run: black --check --diff src tests

--- a/src/freshcart/api/main.py
+++ b/src/freshcart/api/main.py
@@ -4,14 +4,16 @@ from typing import Any, Dict
 
 from fastapi import FastAPI
 
-from freshcart.domain.inventory import Inventory  # NEW
+from freshcart.domain.inventory import Inventory
+
+from .routers import health, inventory, products
 
 
 def create_app(settings: Dict[str, Any] | None = None) -> FastAPI:
     """
-    Factory d'application (recommandée):
-    - facilite les tests
-    - permet d'injecter des settings plus tard
+    Factory d'application:
+    - crée et retourne une instance FastAPI isolée (utile pour tests)
+    - point unique pour injecter des settings plus tard (DB, CORS, etc.)
     """
     app = FastAPI(
         title="FreshCart API",
@@ -24,14 +26,13 @@ def create_app(settings: Dict[str, Any] | None = None) -> FastAPI:
 
     settings = settings or {}
 
-    # --- état applicatif en mémoire (pour le sprint actuel) ---
-    app.state.inventory = Inventory()  # NEW
+    # État applicatif en mémoire pour ce sprint (remplacé plus tard par une DB)
+    app.state.inventory = Inventory()
 
-    # --- routers ---
-    from .routers import health, products  # NEW
-
+    # Brancher les routers
     app.include_router(health.router)
-    app.include_router(products.router)  # NEW
+    app.include_router(products.router)
+    app.include_router(inventory.router)
 
     return app
 
@@ -39,6 +40,7 @@ def create_app(settings: Dict[str, Any] | None = None) -> FastAPI:
 if __name__ == "__main__":
     import uvicorn
 
+    # Lance uvicorn avec la factory (option factory=True)
     uvicorn.run(
         "freshcart.api.main:create_app",
         factory=True,

--- a/src/freshcart/api/routers/inventory.py
+++ b/src/freshcart/api/routers/inventory.py
@@ -1,0 +1,29 @@
+"""
+Router /inventory
+
+Expose :
+- GET /inventory/value : somme des final_price() de l'inventaire
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi import APIRouter, Depends, Request
+
+from freshcart.domain.inventory import Inventory
+
+router = APIRouter(prefix="/inventory", tags=["inventory"])
+
+
+def get_inventory(request: Request) -> Inventory:
+    inv = getattr(request.app.state, "inventory", None)
+    if inv is None:
+        raise RuntimeError("Inventory is not initialized on app.state")
+    return inv
+
+
+@router.get("/value", response_model=Dict[str, float])
+def get_total_value(inv: Inventory = Depends(get_inventory)) -> dict[str, float]:
+    """Retourne la somme des final_price() (arrondie côté domaine)."""
+    return {"total_value": inv.total_value()}

--- a/src/freshcart/api/routers/products.py
+++ b/src/freshcart/api/routers/products.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-# SUPPRIMER: from datetime import date
-from typing import List, Literal  # <-- on réintroduit List pour mypy compat
+from typing import List, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
@@ -12,6 +11,7 @@ from freshcart.domain.products import PerishableProduct, Product
 router = APIRouter(prefix="/products", tags=["products"])
 
 
+# Dépendance: récupérer l'inventaire stocké dans app.state
 def get_inventory(request: Request) -> Inventory:
     inv = getattr(request.app.state, "inventory", None)
     if inv is None:
@@ -19,6 +19,7 @@ def get_inventory(request: Request) -> Inventory:
     return inv
 
 
+# Mapping domaine -> schéma de sortie API
 def to_product_out(p: Product) -> ProductOut:
     type_value: Literal["regular", "perishable"]
     if hasattr(p, "expiry_date"):
@@ -38,16 +39,24 @@ def to_product_out(p: Product) -> ProductOut:
     )
 
 
-@router.post("", response_model=ProductOut, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=ProductOut,
+    status_code=status.HTTP_201_CREATED,
+)
 def create_product(
-    payload: ProductCreate, inv: Inventory = Depends(get_inventory)
+    payload: ProductCreate,
+    inv: Inventory = Depends(get_inventory),
 ) -> ProductOut:
+    # Unicité basique du SKU
     if any(it.sku == payload.sku for it in inv.all()):
         raise HTTPException(status_code=400, detail="SKU already exists")
 
     if payload.type == "regular":
         p = Product(payload.sku, payload.name, payload.initial_price)
     else:
+        # Pydantic v2 garantit que expiry_date est renseigné pour les périssables,
+        # mais mypy ne l'infère pas → assertion pour le typage statique.
         assert payload.expiry_date is not None, "expiry_date validated by Pydantic"
         p = PerishableProduct(
             payload.sku,
@@ -60,7 +69,14 @@ def create_product(
     return to_product_out(p)
 
 
-@router.get("", response_model=List[ProductOut])  # <-- List[...] au lieu de list[...]
+@router.get("", response_model=List[ProductOut])
 def list_products(inv: Inventory = Depends(get_inventory)) -> List[ProductOut]:
-    items = sorted(inv.all())
+    items = sorted(inv.all())  # tri naturel via dataclass(order=True)
     return [to_product_out(p) for p in items]
+
+
+@router.get("/expired", response_model=List[ProductOut])
+def list_expired(inv: Inventory = Depends(get_inventory)) -> List[ProductOut]:
+    """Liste uniquement les périssables périmés."""
+    expired_items = inv.expired()
+    return [to_product_out(p) for p in expired_items]

--- a/tests/test_api_inventory.py
+++ b/tests/test_api_inventory.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from fastapi.testclient import TestClient
+
+from freshcart.api.main import create_app
+
+
+def test_inventory_value_and_expired() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    # 1) 2 produits réguliers
+    client.post("/products", json={"sku": "A1", "name": "Café", "initial_price": 8.0})
+    client.post("/products", json={"sku": "A2", "name": "Sucre", "initial_price": 2.0})
+
+    # 2) 1 périssable périmé (hier) -> final_price=0.0
+    expired_date = (date.today() - timedelta(days=1)).isoformat()
+    client.post(
+        "/products",
+        json={
+            "sku": "P0",
+            "name": "Yaourt",
+            "initial_price": 3.0,
+            "type": "perishable",
+            "expiry_date": expired_date,
+        },
+    )
+
+    # 3) 1 périssable bientôt périmé (2 jours) -> -50% sur final_price
+    soon_date = (date.today() + timedelta(days=2)).isoformat()
+    client.post(
+        "/products",
+        json={
+            "sku": "P2",
+            "name": "Lait",
+            "initial_price": 4.0,
+            "type": "perishable",
+            "expiry_date": soon_date,
+        },
+    )
+
+    # total_value = 8.0 + 2.0 + 0.0 + 2.0 = 12.0
+    r_val = client.get("/inventory/value")
+    assert r_val.status_code == 200
+    assert r_val.json() == {"total_value": 12.0}
+
+    # expired → doit contenir P0
+    r_exp = client.get("/products/expired")
+    assert r_exp.status_code == 200
+    skus = [item["sku"] for item in r_exp.json()]
+    assert "P0" in skus


### PR DESCRIPTION
What

Ajoute deux endpoints API :

GET /inventory/value → retourne la somme des final_price() de l’inventaire.

GET /products/expired → retourne uniquement les produits périmés.

Branche un nouveau router inventory.py (/inventory).

Nettoyage style/qualité :

signature du POST /products reformattée (E501).

imports organisés (I001) dans api/main.py et api/routers/products.py.

🤔 Why

Offrir des vues utiles côté consommation API (valeur totale, périmés) qui exercent la logique métier existante.

Préparer le terrain pour les features suivantes (tri/filtre, pagination, puis persistance DB).

Maintenir une qualité homogène (Ruff/Black) pour faciliter les revues et éviter les “diffs bruités”.

🛠️ How

Nouveau fichier : src/freshcart/api/routers/inventory.py avec GET /inventory/value.

Ajouts dans src/freshcart/api/routers/products.py : GET /products/expired.

src/freshcart/api/main.py : branchement des routers health, products, inventory.

Formatage Black + corrections Ruff.

🔬 How to test

Local :

pytest
ruff check src tests
mypy src
python -m freshcart.api.main  # puis ouvrir http://127.0.0.1:8000/docs


Vérifier :

POST /products (régulier + périssable)

GET /products, GET /products/expired

GET /inventory/value → retourne p.ex. {"total_value": 12.0}

CI : les workflows test/lint/type doivent être verts.

📌 Notes

Stockage toujours in-memory pour ce sprint.

Pas de breaking changes.

README sera mis à jour dans une tâche dédiée (doc API).